### PR TITLE
fix: build again before publishing to update version in final bundle

### DIFF
--- a/packages/autodesk/package.json
+++ b/packages/autodesk/package.json
@@ -27,6 +27,7 @@
     "watch": "concurrently -n code,types \"pnpm watch:code\" \"pnpm watch:types\"",
     "watch:code": "node ./.esbuild/watch.js",
     "watch:types": "./node_modules/typescript/bin/tsc --watch",
+    "prepack": "pnpm build",
     "semantic-release": "semantic-release"
   },
   "devDependencies": {

--- a/packages/matterport/package.json
+++ b/packages/matterport/package.json
@@ -26,6 +26,7 @@
     "watch": "concurrently -n code,types \"pnpm watch:code\" \"pnpm watch:types\"",
     "watch:code": "node ./.esbuild/watch.js",
     "watch:types": "./node_modules/typescript/bin/tsc --watch",
+    "prepack": "pnpm build",
     "semantic-release": "semantic-release"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "watch": "./node_modules/typescript/bin/tsc && vite build --watch",
     "build": "./node_modules/typescript/bin/tsc && vite build && cp package.json dist/package.json && cp README.md dist/README.md",
+    "prepack": "pnpm build",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "eslint --fix 'src/**/*.{jsx,ts,tsx}'",
     "format": "prettier --write src//**/*.{ts,tsx,css} --config ./.prettierrc",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -31,6 +31,7 @@
     "watch": "concurrently -n code,types \"pnpm run watch:code\" \"pnpm watch:types\"",
     "watch:code": "node ./.esbuild/watch.js",
     "watch:types": "./node_modules/typescript/bin/tsc --watch --outDir ./dist",
+    "prepack": "pnpm build",
     "test:unit": "jest",
     "test:unit:watch": "jest --watch",
     "test:unit:coverage": "jest --coverage",

--- a/packages/socket-client/package.json
+++ b/packages/socket-client/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "node ./.esbuild/build.js",
     "postbuild": "./node_modules/typescript/bin/tsc --emitDeclarationOnly --declaration",
+    "prepack": "pnpm build",
     "watch": "concurrently -n code,types \"pnpm watch:code\" \"pnpm watch:types\"",
     "watch:code": "node ./.esbuild/watch.js",
     "watch:types": "./node_modules/typescript/bin/tsc --watch --outDir dist",

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "node ./.esbuild/build.js",
     "postbuild": "./node_modules/typescript/bin/tsc",
+    "prepack": "pnpm build",
     "watch": "concurrently -n code,types \"pnpm watch:code\" \"pnpm watch:types\"",
     "watch:code": "node ./.esbuild/watch.js",
     "watch:types": "./node_modules/typescript/bin/tsc --watch",

--- a/packages/yjs/package.json
+++ b/packages/yjs/package.json
@@ -17,6 +17,7 @@
     "test:unit:coverage": "jest --coverage",
     "test:unit:ci": "jest --ci",
     "build": "node ./.esbuild/build.js",
+    "prepack": "pnpm build",
     "postbuild": "./node_modules/typescript/bin/tsc --declaration --emitDeclarationOnly --declarationDir dist",
     "watch": "concurrently -n code,types \"pnpm watch:code\" \"pnpm watch:types\"",
     "watch:code": "node ./.esbuild/watch.js",


### PR DESCRIPTION
This pull request includes updates to the `package.json` files across multiple packages to add a `prepack` script that ensures the build process runs before the package is packed. This change helps maintain consistency and ensures that the latest version number is always included.

Updates to `package.json` files:

* [`packages/autodesk/package.json`](diffhunk://#diff-fda78bcb7c1e4df1975b9b87c130dae24fa068456fce45270b1cdcfdbcdaa286R30): Added a `prepack` script to run `pnpm build`.
* [`packages/matterport/package.json`](diffhunk://#diff-6439a2b9b48571cbed89fbe3ded3540ca61ad93766f7aa0767c14202423b50daR29): Added a `prepack` script to run `pnpm build`.
* [`packages/react/package.json`](diffhunk://#diff-1f344ac391eeecc21ec0f01fb07430a47f4b80d20485c125447d54c33c4bbfc4R9): Added a `prepack` script to run `pnpm build`.
* [`packages/realtime/package.json`](diffhunk://#diff-1d45e13af8227c7410f7061b0ca533dfe16e4ac09c0a4ba7d7045132be1be476R34): Added a `prepack` script to run `pnpm build`.
* [`packages/socket-client/package.json`](diffhunk://#diff-a5a2807b15cb71fd540ca63a49460f24ad10d8fe6a600993ac5df5a9794fd4abR18): Added a `prepack` script to run `pnpm build`.
* [`packages/three/package.json`](diffhunk://#diff-8a39b76fa88635fade70334a30087f5d54513495a6c97b5e81dbb31b310e0fa7R26): Added a `prepack` script to run `pnpm build`.
* [`packages/yjs/package.json`](diffhunk://#diff-e7dd2f3c9f45f26c3aea5b4978bfaf8255d8a2304a4568ed2dd2ae521a01e3c1R20): Added a `prepack` script to run `pnpm build`.