### PR TITLE
fix(Realtime): unsubscribe from all callbacks if no callback is provided

### DIFF
--- a/packages/realtime/src/services/channel/channel.test.ts
+++ b/packages/realtime/src/services/channel/channel.test.ts
@@ -1,10 +1,10 @@
 import { LIMITS_MOCK } from '../../../__mocks__/limits.mock';
 import { MOCK_OBSERVER_HELPER } from '../../../__mocks__/observer-helper.mock';
 import { MOCK_LOCAL_PARTICIPANT } from '../../../__mocks__/participants.mock';
+import { RealtimeChannelState } from '../../component/types';
 import { IOC } from '../io';
 
 import { Channel } from './channel';
-import { RealtimeChannelState } from '../../component/types';
 
 jest.mock('lodash/throttle', () => jest.fn((fn) => fn));
 jest.useFakeTimers();
@@ -75,6 +75,15 @@ describe('Realtime Channel', () => {
       ChannelInstance['observers']['test'] = MOCK_OBSERVER_HELPER;
       const spy = jest.spyOn(ChannelInstance['observers']['test'], 'unsubscribe' as any);
       ChannelInstance.unsubscribe('test', () => {});
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    test('should reset an event if no callback is provided', () => {
+      ChannelInstance['observers']['test'] = MOCK_OBSERVER_HELPER;
+      const spy = jest.spyOn(ChannelInstance['observers']['test'], 'reset' as any);
+
+      ChannelInstance.unsubscribe('test');
 
       expect(spy).toHaveBeenCalled();
     });

--- a/packages/realtime/src/services/channel/channel.ts
+++ b/packages/realtime/src/services/channel/channel.ts
@@ -110,6 +110,11 @@ export class Channel extends Observable {
     event: string,
     callback?: Callback<T>,
   ): void => {
+    if (!callback) {
+      this.observers[event]?.reset();
+      return;
+    }
+
     this.observers[event]?.unsubscribe(callback);
   };
 


### PR DESCRIPTION
The following behaviors were expected when unsubscribing from events in Realtime channels:
1. If a callback is provided, unsubscribe specifically from that callback. That is, when the event is triggered, the callback will not be called
2. If no callback is provided, unsubscribe from all callbacks. Even if the event is triggered, nothing will happen and nothing will be called

The first behavior was OK. But we were making no validations to make sure that the second happened, so it simply never unsubscribed from anything if no callback was provided when doing `channel.unsubscribe(EVENT_NAME)`;

This PR fixes this by resetting the event observer if the callback is undefined when unsubscribing from an event.