### PR TITLE
fix: don't try to unsubscribe when the observers are undefined

### DIFF
--- a/packages/sdk/src/common/utils/observable.ts
+++ b/packages/sdk/src/common/utils/observable.ts
@@ -31,7 +31,7 @@ export abstract class Observable {
   public unsubscribe = (type: string, callback?: (data: unknown) => void): void => {
     this.logger.log(`unsubscribed from ${type} event`);
 
-    if (!this.observers[type]) return;
+    if (!this.observers?.[type]) return;
 
     if (!callback) {
       this.observers[type].destroy();


### PR DESCRIPTION
This pull request includes a small change to the `Observable` class in the `packages/sdk/src/common/utils/observable.ts` file. The change improves the code by using optional chaining to check for the existence of `this.observers`.

* [`packages/sdk/src/common/utils/observable.ts`](diffhunk://#diff-299047f0ad8617ec842b8bf072d46cf7637da9b0f0776e6f3719da5745771b24L34-R34): Modified the `unsubscribe` method to use optional chaining when accessing `this.observers`.