### PR TITLE
Matterport ambient light and Video React host type

### DIFF
--- a/apps/playground/src/pages/video-with-react.tsx
+++ b/apps/playground/src/pages/video-with-react.tsx
@@ -4,14 +4,19 @@ import {
   SuperVizRoomProvider,
   VideoConference,
 } from "@superviz/react-sdk";
+import { ParticipantType } from "@superviz/sdk";
+import { useSearchParams } from "react-router-dom";
+
 
 function Room() {
+  const [searchParams] = useSearchParams();
+  const type = (searchParams.get("userType") as ParticipantType) || ParticipantType.HOST;
 
   return (
     <div className="p-5 h-full bg-gray-200 flex flex-col gap-5">
       <div className="shadow-none h-[90%] overflow-auto rounded-sm">\
         test
-        <VideoConference participantType="host" /> 
+        <VideoConference participantType={type} onHostChange={(host) => { console.log(host) }} /> 
       </div>
     </div>
   );

--- a/packages/matterport/src/services/adapter.ts
+++ b/packages/matterport/src/services/adapter.ts
@@ -199,8 +199,8 @@ export class Presence3D {
     this.useStore = undefined;
 
     this.isAttached = false;
-    this.ambientLight.stop();
-    this.directionalLight.stop();
+    this.ambientLight?.stop();
+    this.directionalLight?.stop();
 
     this.participants.forEach((participant) => {
       this.removeParticipant(participant, true);

--- a/packages/react/src/components/video/video.types.ts
+++ b/packages/react/src/components/video/video.types.ts
@@ -59,7 +59,7 @@ export interface VideoCallbacks {
   onMeetingStateChange?: (state: MeetingState) => void;
   onSameAccountError?: () => void;
   onDevicesStateChange?: (state: DeviceEvent) => void;
-  onHostChange?: (participantId: string) => void;
+  onHostChange?: (participant: Participant) => void;
   onHostAvailable?: () => void;
   onNoHostAvailable?: () => void;
   onParticipantJoin?: (participant: Participant) => void;


### PR DESCRIPTION
This pull request includes several changes to improve the handling of participant types and enhance the robustness of the codebase. The most important changes include adding new imports, modifying the `VideoConference` component, and updating the `onHostChange` callback.

Enhancements to participant handling:

* [`apps/playground/src/pages/video-with-react.tsx`](diffhunk://#diff-433a47077b9f00f445b550d682d48e87f611c00d01b905f0e4ac24252328dfb9R7-R19): Added imports for `ParticipantType` from `@superviz/sdk` and `useSearchParams` from `react-router-dom`. Updated the `VideoConference` component to dynamically set the `participantType` based on URL search parameters and added an `onHostChange` callback to log the host changes.

Code robustness improvements:

* [`packages/matterport/src/services/adapter.ts`](diffhunk://#diff-c1b02630db176c7b5f23fd4f5315126ecad2151cb1f2c7728ce26aad4ad54922L202-R203): Added optional chaining to safely call the `stop` method on `ambientLight` and `directionalLight` properties.

Callback updates:

* [`packages/react/src/components/video/video.types.ts`](diffhunk://#diff-ca20e06b2ec03f5966486a8d89f63d99ba24c0ee75e4300dbe69278b3d26ab8fL62-R62): Modified the `onHostChange` callback in the `VideoCallbacks` interface to pass a `Participant` object instead of a `participantId` string.