### PR TITLE
fix: validate the apiKey with the watermark and the limits

### DIFF
--- a/apps/playground/src/pages/video.tsx
+++ b/apps/playground/src/pages/video.tsx
@@ -42,6 +42,9 @@ export function Video() {
 
     video.current = new VideoConference({
       userType: type,
+      collaborationMode: { 
+        enabled: false
+      }
     });
 
     room.current.addComponent(video.current);


### PR DESCRIPTION
### SDK Initialization and Authentication:
* [`packages/sdk/src/core/index.ts`](diffhunk://#diff-fff984cde737ff6133a9ab9da5f753b33bc1b4295f80bfc2a8ebc79dc409456aL6-R6): Changed the import of the authentication service from a named import to a default import.
* [`packages/sdk/src/core/index.ts`](diffhunk://#diff-fff984cde737ff6133a9ab9da5f753b33bc1b4295f80bfc2a8ebc79dc409456aL146-R157): Updated the SDK initialization function to handle authentication inline with other service calls and improved error handling for API key validation.