### PR TITLE
fix: fix the type of configuration in the realtime and room

### DIFF
--- a/packages/realtime/src/services/config/index.ts
+++ b/packages/realtime/src/services/config/index.ts
@@ -1,4 +1,5 @@
 import { get } from 'lodash';
+
 import type { Configuration, Key } from './types';
 
 export class ConfigurationService {
@@ -11,7 +12,7 @@ export class ConfigurationService {
   public get<T>(key: Key, defaultValue?: T): T {
     if (!this.configuration) return defaultValue;
 
-    return get<Configuration, any, T>(this.configuration, key, defaultValue as T) as T;
+    return get<Partial<Configuration>, any, T>(this.configuration, key, defaultValue as T) as T;
   }
 }
 

--- a/packages/room/src/services/config/index.ts
+++ b/packages/room/src/services/config/index.ts
@@ -12,7 +12,7 @@ export class ConfigurationService {
   public get<T>(key: Key, defaultValue?: T): T {
     if (!this.configuration) return defaultValue;
 
-    return get<Configuration, any, T>(this.configuration, key, defaultValue as T) as T;
+    return get<Partial<Configuration>, any, T>(this.configuration, key, defaultValue as T) as T;
   }
 }
 


### PR DESCRIPTION
This pull request includes changes to the `ConfigurationService` class in two different files to improve type safety when retrieving configuration values. The changes involve modifying the type parameter in the `get` method to use `Partial<Configuration>` instead of `Configuration`.

Type safety improvements:

* [`packages/realtime/src/services/config/index.ts`](diffhunk://#diff-a39d6ae2ea0fd5f43bad07c2dddc125e374df2d610c9f45349f72964c35d1bcdL14-R15): Changed the type parameter in the `get` method of the `ConfigurationService` class to use `Partial<Configuration>` for better type safety.
* [`packages/room/src/services/config/index.ts`](diffhunk://#diff-7ec849478832a5f786d3fb06969704b4901a407db01d0c56cc257dc526262c30L15-R15): Changed the type parameter in the `get` method of the `ConfigurationService` class to use `Partial<Configuration>` for better type safety.