### PR TITLE
Add group and rename developer token

### DIFF
--- a/apps/playground/src/pages/superviz-room.tsx
+++ b/apps/playground/src/pages/superviz-room.tsx
@@ -17,10 +17,14 @@ export function SuperVizRoom() {
     const uuid = generateId();
 
     const newRoom = await createRoom({
-      developerKey: SUPERVIZ_KEY,
+      developerToken: SUPERVIZ_KEY,
       participant: {
         name: "Participant Name",
         id: uuid,
+      },
+      group: {
+        name: SUPERVIZ_ROOM_PREFIX,
+        id: SUPERVIZ_ROOM_PREFIX,
       },
       roomId: `${SUPERVIZ_ROOM_PREFIX}-${componentName}`,
       debug: true, 

--- a/packages/room/__mocks__/config.mock.ts
+++ b/packages/room/__mocks__/config.mock.ts
@@ -6,6 +6,10 @@ export const MOCK_CONFIG: Configuration = {
   roomId: 'unit-test-room-id',
   debug: true,
   apiUrl: 'unit-test-api-url',
+  group: {
+    id: 'unit-test-group-id',
+    name: 'unit-test-group-name',
+  },
   limits: {
     videoConference: {
       canUse: true,

--- a/packages/room/src/common/types/group.types.ts
+++ b/packages/room/src/common/types/group.types.ts
@@ -1,0 +1,4 @@
+export type Group = {
+  id: string
+  name: string
+}

--- a/packages/room/src/index.test.ts
+++ b/packages/room/src/index.test.ts
@@ -14,7 +14,7 @@ jest.mock('./services/api', () => ({
 describe('createRoom', () => {
   test('creates a room with valid params', async () => {
     const params = {
-      developerKey: 'abc123',
+      developerToken: 'abc123',
       roomId: 'abc123',
       participant: {
         id: 'abc123',
@@ -33,7 +33,7 @@ describe('createRoom', () => {
 
   test('throws an error if the room id is invalid', async () => {
     const params = {
-      developerKey: 'abc123',
+      developerToken: 'abc123',
       roomId: 'abc$',
       participant: {
         id: 'abc123',
@@ -53,7 +53,7 @@ describe('createRoom', () => {
 
   test('throws an error if the participant id is invalid', async () => {
     const params = {
-      developerKey: 'abc123',
+      developerToken: 'abc123',
       roomId: 'abc123:',
       participant: {
         id: 'abc$',
@@ -73,7 +73,7 @@ describe('createRoom', () => {
 
   test('throws an error if the group id is invalid', async () => {
     const params = {
-      developerKey: 'abc123',
+      developerToken: 'abc123',
       roomId: 'abc123',
       participant: {
         id: 'abc123',
@@ -93,7 +93,7 @@ describe('createRoom', () => {
 
   test('throws an error if the developer key is missing', async () => {
     const params = {
-      developerKey: '',
+      developerToken: '',
       roomId: 'abc123',
       participant: {
         id: 'abc123',
@@ -106,7 +106,7 @@ describe('createRoom', () => {
     };
 
     const createRoomPromise = createRoom(params);
-    await expect(createRoomPromise).rejects.toThrow('[SuperViz | Room] Developer Key is required');
+    await expect(createRoomPromise).rejects.toThrow('[SuperViz | Room] Developer Token is required');
 
     const params2 = {
       roomId: 'abc123',
@@ -118,12 +118,12 @@ describe('createRoom', () => {
 
     // @ts-ignore
     const createRoomPromise2 = createRoom(params2);
-    await expect(createRoomPromise2).rejects.toThrow('[SuperViz | Room] Developer Key is required');
+    await expect(createRoomPromise2).rejects.toThrow('[SuperViz | Room] Developer Token is required');
   });
 
   test('sets up the environment correctly', async () => {
     const params = {
-      developerKey: 'abc123',
+      developerToken: 'abc123',
       roomId: 'abc123',
       participant: {
         id: 'abc123',
@@ -143,7 +143,7 @@ describe('createRoom', () => {
     expect(config.get('debug')).toBe(false);
 
     const paramsWithOptionalFields = {
-      developerKey: 'abc123',
+      developerToken: 'abc123',
       roomId: 'abc123',
       participant: {
         id: 'abc123',
@@ -167,7 +167,7 @@ describe('createRoom', () => {
 
   test('set up the environment with the correct API URL', async () => {
     const params = {
-      developerKey: 'abc123',
+      developerToken: 'abc123',
       roomId: 'abc123',
       participant: {
         id: 'abc123',
@@ -184,7 +184,7 @@ describe('createRoom', () => {
     expect(config.get('apiUrl')).toBe('https://api.superviz.com');
 
     const paramsWithProdEnvironment = {
-      developerKey: 'abc123',
+      developerToken: 'abc123',
       roomId: 'abc123',
       participant: {
         id: 'abc123',

--- a/packages/room/src/index.test.ts
+++ b/packages/room/src/index.test.ts
@@ -20,6 +20,10 @@ describe('createRoom', () => {
         id: 'abc123',
         name: 'John Doe',
       },
+      group: {
+        id: 'abc123',
+        name: 'Group',
+      },
     };
 
     const room = await createRoom(params);
@@ -34,6 +38,10 @@ describe('createRoom', () => {
       participant: {
         id: 'abc123',
         name: 'John Doe',
+      },
+      group: {
+        id: 'abc123',
+        name: 'Group',
       },
     };
 
@@ -51,11 +59,35 @@ describe('createRoom', () => {
         id: 'abc$',
         name: 'John Doe',
       },
+      group: {
+        id: 'abc123',
+        name: 'Group',
+      },
     };
 
     const createRoomPromise = createRoom(params);
     await expect(createRoomPromise).rejects.toThrow(
       '[SuperViz | Room] Participant id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».|\'"',
+    );
+  });
+
+  test('throws an error if the group id is invalid', async () => {
+    const params = {
+      developerKey: 'abc123',
+      roomId: 'abc123',
+      participant: {
+        id: 'abc123',
+        name: 'John Doe',
+      },
+      group: {
+        id: 'abc$',
+        name: 'Group',
+      },
+    };
+
+    const createRoomPromise = createRoom(params);
+    await expect(createRoomPromise).rejects.toThrow(
+      '[SuperViz | Room] Group id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».|\'"',
     );
   });
 
@@ -66,6 +98,10 @@ describe('createRoom', () => {
       participant: {
         id: 'abc123',
         name: 'John Doe',
+      },
+      group: {
+        id: 'abc123',
+        name: 'Group',
       },
     };
 
@@ -93,6 +129,10 @@ describe('createRoom', () => {
         id: 'abc123',
         name: 'John Doe',
       },
+      group: {
+        id: 'abc123',
+        name: 'Group',
+      },
     };
 
     await createRoom(params);
@@ -108,6 +148,10 @@ describe('createRoom', () => {
       participant: {
         id: 'abc123',
         name: 'John Doe',
+      },
+      group: {
+        id: 'abc123',
+        name: 'Group',
       },
       debug: true,
       environment: 'dev' as 'dev',
@@ -129,6 +173,10 @@ describe('createRoom', () => {
         id: 'abc123',
         name: 'John Doe',
       },
+      group: {
+        id: 'abc123',
+        name: 'Group',
+      },
     };
 
     await createRoom(params);
@@ -141,6 +189,10 @@ describe('createRoom', () => {
       participant: {
         id: 'abc123',
         name: 'John Doe',
+      },
+      group: {
+        id: 'abc123',
+        name: 'Group',
       },
       environment: 'dev' as 'dev',
     };

--- a/packages/room/src/index.ts
+++ b/packages/room/src/index.ts
@@ -14,8 +14,6 @@ import { InitializeRoomParams, InitializeRoomSchema } from './types';
  * It also validates the provided API key and fetches additional configuration data
  * such as watermarks and limits from the server.
  *
- * @param developerKey - The API key provided by the developer.
- * @param roomId - The ID of the room to be configured.
  * @throws
  *  Will throw an error if the configuration fails to load
  *  from the server or if the API key is invalid.
@@ -25,7 +23,9 @@ async function setUpEnvironment({
   roomId,
   environment,
   debug: enableDebug,
+  group,
 }: InitializeRoomParams): Promise<void> {
+  config.set('group', group);
   config.set('apiKey', developerKey);
   config.set('debug', !!enableDebug);
   config.set('roomId', roomId);

--- a/packages/room/src/index.ts
+++ b/packages/room/src/index.ts
@@ -19,14 +19,14 @@ import { InitializeRoomParams, InitializeRoomSchema } from './types';
  *  from the server or if the API key is invalid.
  */
 async function setUpEnvironment({
-  developerKey,
+  developerToken,
   roomId,
   environment,
   debug: enableDebug,
   group,
 }: InitializeRoomParams): Promise<void> {
   config.set('group', group);
-  config.set('apiKey', developerKey);
+  config.set('apiKey', developerToken);
   config.set('debug', !!enableDebug);
   config.set('roomId', roomId);
   config.set('environment', environment ?? 'prod');
@@ -40,9 +40,9 @@ async function setUpEnvironment({
   }
 
   const [canAccess, waterMark, limits] = await Promise.all([
-    ApiService.validateApiKey(developerKey),
-    ApiService.fetchWaterMark(developerKey),
-    ApiService.fetchLimits(developerKey),
+    ApiService.validateApiKey(developerToken),
+    ApiService.fetchWaterMark(developerToken),
+    ApiService.fetchLimits(developerToken),
   ]).catch((error) => {
     console.log(error);
     throw new Error('[SuperViz | Room] Failed to load configuration from server');
@@ -66,7 +66,7 @@ async function setUpEnvironment({
  */
 export async function createRoom(params: InitializeRoomParams): Promise<Room> {
   try {
-    const { developerKey, participant, roomId } = InitializeRoomSchema.parse(params);
+    const { developerToken, participant, roomId } = InitializeRoomSchema.parse(params);
 
     await setUpEnvironment(params);
 

--- a/packages/room/src/services/config/types.ts
+++ b/packages/room/src/services/config/types.ts
@@ -1,3 +1,5 @@
+import { Group } from '../../common/types/group.types';
+
 export interface Configuration {
   roomId: string;
   environment: 'dev' | 'prod';
@@ -6,6 +8,7 @@ export interface Configuration {
   debug: boolean;
   limits: ComponentLimits;
   waterMark: boolean;
+  group: Group
 }
 
 type Paths<T> = T extends object

--- a/packages/room/src/types.ts
+++ b/packages/room/src/types.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 const pattern = /^[-_&@+=,(){}\[\]\/«».|'"#a-zA-Z0-9À-ÿ\s]*$/;
 
 export const InitializeRoomSchema = z.object({
-  developerKey: z.string({ message: '[SuperViz | Room] Developer Key is required' }).min(1, { message: '[SuperViz | Room] Developer Key is required' }),
+  developerToken: z.string({ message: '[SuperViz | Room] Developer Token is required' }).min(1, { message: '[SuperViz | Room] Developer Token is required' }),
   roomId: z.string().regex(pattern, { message: '[SuperViz | Room] Room id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».|\'"' }),
   participant: z.object({
     id: z.string().regex(pattern, { message: '[SuperViz | Room] Participant id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».|\'"' }),

--- a/packages/room/src/types.ts
+++ b/packages/room/src/types.ts
@@ -9,6 +9,10 @@ export const InitializeRoomSchema = z.object({
     id: z.string().regex(pattern, { message: '[SuperViz | Room] Participant id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».|\'"' }),
     name: z.string(),
   }),
+  group: z.object({
+    id: z.string().regex(pattern, { message: '[SuperViz | Room] Group id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».|\'"' }),
+    name: z.string(),
+  }),
   debug: z.boolean().optional(),
   environment: z.enum(['dev', 'prod'], { message: '[SuperViz | Room] Environment must be either "dev" or "prod"' }).optional(),
 });


### PR DESCRIPTION
This pull request includes several changes to enhance the `createRoom` functionality by introducing a `group` parameter and replacing the `developerKey` with `developerToken`. The changes span multiple files to ensure the new features are properly integrated and tested.

### Key Changes:

#### Introducing Group Parameter:
* [`packages/room/src/common/types/group.types.ts`](diffhunk://#diff-1c7f1718cd0af96f5ddf2c714bbeacee59d7b760049b15038d9f91554e578758R1-R4): Added a new `Group` type definition.
* [`packages/room/src/types.ts`](diffhunk://#diff-8c46787887b5dd4d4a702b039d5c2cf10a0c7b0f8cddf3687942eef7b6e5180fL6-R15): Updated `InitializeRoomSchema` to include validation for the new `group` parameter.
* [`packages/room/src/services/config/types.ts`](diffhunk://#diff-29c46fdb8d410ae1d11250ac461c948ee1a42624ddabcb00dbd8d444e426e8f9R1-R2): Added `group` to the `Configuration` interface. [[1]](diffhunk://#diff-29c46fdb8d410ae1d11250ac461c948ee1a42624ddabcb00dbd8d444e426e8f9R1-R2) [[2]](diffhunk://#diff-29c46fdb8d410ae1d11250ac461c948ee1a42624ddabcb00dbd8d444e426e8f9R11)

#### Replacing Developer Key with Developer Token:
* [`packages/room/src/index.ts`](diffhunk://#diff-78719ce3638e8ed5c2d90d38ca3bf38abfde61062d30667064dcaf92906d70f3L17-R29): Replaced `developerKey` with `developerToken` in the `setUpEnvironment` and `createRoom` functions. [[1]](diffhunk://#diff-78719ce3638e8ed5c2d90d38ca3bf38abfde61062d30667064dcaf92906d70f3L17-R29) [[2]](diffhunk://#diff-78719ce3638e8ed5c2d90d38ca3bf38abfde61062d30667064dcaf92906d70f3L43-R45) [[3]](diffhunk://#diff-78719ce3638e8ed5c2d90d38ca3bf38abfde61062d30667064dcaf92906d70f3L69-R69)

#### Updating Tests:
* [`packages/room/src/index.test.ts`](diffhunk://#diff-6f3b6174741fde1c2c1dea336297c9ead1f7418bea875d1218febb3c8c29182fL17-R26): Updated tests to use `developerToken` instead of `developerKey` and added tests for the new `group` parameter. [[1]](diffhunk://#diff-6f3b6174741fde1c2c1dea336297c9ead1f7418bea875d1218febb3c8c29182fL17-R26) [[2]](diffhunk://#diff-6f3b6174741fde1c2c1dea336297c9ead1f7418bea875d1218febb3c8c29182fL32-R45) [[3]](diffhunk://#diff-6f3b6174741fde1c2c1dea336297c9ead1f7418bea875d1218febb3c8c29182fL48-R65) [[4]](diffhunk://#diff-6f3b6174741fde1c2c1dea336297c9ead1f7418bea875d1218febb3c8c29182fR74-R109) [[5]](diffhunk://#diff-6f3b6174741fde1c2c1dea336297c9ead1f7418bea875d1218febb3c8c29182fL85-R135) [[6]](diffhunk://#diff-6f3b6174741fde1c2c1dea336297c9ead1f7418bea875d1218febb3c8c29182fL106-R155) [[7]](diffhunk://#diff-6f3b6174741fde1c2c1dea336297c9ead1f7418bea875d1218febb3c8c29182fL126-R196)

#### Mock Configuration:
* [`packages/room/__mocks__/config.mock.ts`](diffhunk://#diff-1367660e8bf31e88d9e6e6313259a191728dd25ff9f7fab14abc4a3ae4db249fR9-R12): Added a `group` object to the mock configuration.

#### SuperViz Room Component:
* [`apps/playground/src/pages/superviz-room.tsx`](diffhunk://#diff-03c618fce68e857452d232d005e6947db6cc47b8d357b2302db3e747f85c33c1L20-R28): Updated `createRoom` call to include the `group` parameter and use `developerToken`.