### PR TITLE
feat: introducing stores to room

### DIFF
--- a/packages/room/src/core/index.test.ts
+++ b/packages/room/src/core/index.test.ts
@@ -108,14 +108,14 @@ describe('Room', () => {
     });
   });
 
-  it('should handle local participant joined room event', () => {
+  it('should handle local participant joined room event', async () => {
     const data = { id: '123' } as any;
     const emitSpy = jest.spyOn(room as any, 'emit');
     const updateSpy = jest.spyOn(room['room'].presence, 'update');
     const emitExpected = room['transfromSocketMesssageToParticipant'](data);
     const updateExpected = room['createParticipant'](params.participant);
 
-    room['onLocalParticipantJoinedRoom'](data);
+    await room['onLocalParticipantJoinedRoom'](data);
 
     expect(updateSpy).toHaveBeenCalledWith({
       ...updateExpected,
@@ -244,7 +244,8 @@ describe('Room', () => {
       },
       activeComponents: [],
     }]);
-    expect(room['participants'].size).toBe(mockParticipants.length);
+
+    expect(Object.keys(room['participants']).length).toBe(mockParticipants.length);
   });
 
   it('should return empty array when room is not connected', async () => {

--- a/packages/room/src/services/slot/index.test.ts
+++ b/packages/room/src/services/slot/index.test.ts
@@ -62,8 +62,13 @@ describe('SlotService', () => {
   it('should set default slot', () => {
     slotService['setDefaultSlot']();
 
-    expect(slotService.slot).toEqual(SlotService.getDefaultSlot());
-    expect(room.presence.update).toHaveBeenCalledWith({ slot: SlotService.getDefaultSlot() });
+    const expected = {
+      ...SlotService.getDefaultSlot(),
+      timestamp: expect.any(Number),
+    };
+
+    expect(slotService.slot).toEqual(expected);
+    expect(room.presence.update).toHaveBeenCalledWith({ slot: expected });
   });
 
   it('should validate and assign slot type', async () => {

--- a/packages/room/src/stores/common/types.ts
+++ b/packages/room/src/stores/common/types.ts
@@ -1,0 +1,48 @@
+import { useGlobalStore } from '../global';
+
+type Callback<T, K = undefined> = (a: T, b?: K) => void;
+
+export type SimpleSubject<T> = {
+  value: T;
+  publish: Callback<T>;
+  subscribe: Callback<string, Callback<T>>;
+  unsubscribe: Callback<string>;
+};
+
+export type Singleton<T> = {
+  set value(value: T);
+  get value(): T;
+};
+
+export type PublicSubject<T> = {
+  get value(): T;
+  set value(T);
+  subscribe: Callback<string | unknown, Callback<T>>;
+  unsubscribe: Callback<string | unknown>;
+};
+
+export enum StoreType {
+  GLOBAL = 'global-store',
+}
+
+type Subject<T extends (...args: any[]) => any, K extends keyof ReturnType<T>> = ReturnType<T>[K];
+
+type IncompleteStoreApi<T extends (...args: any[]) => any> = {
+  [K in keyof ReturnType<T>]: {
+    subscribe(callback?: (value: Subject<T, K>['value']) => void): void;
+    subject: Subject<T, K>;
+    publish(value: Subject<T, K>['value']): void;
+    value: Subject<T, K>['value'];
+  };
+};
+
+type StoreApi<T extends (...args: any[]) => any> = IncompleteStoreApi<T> & {
+  destroy(): void;
+};
+
+type GlobalStore = StoreType.GLOBAL | `${StoreType.GLOBAL}`;
+
+export type Store<T> = T extends GlobalStore
+  ? StoreApi<typeof useGlobalStore>
+  : never;
+export type StoresTypes = typeof StoreType;

--- a/packages/room/src/stores/common/use-store.ts
+++ b/packages/room/src/stores/common/use-store.ts
@@ -1,0 +1,84 @@
+import { useGlobalStore } from '../global';
+
+import { PublicSubject, Store, StoreType } from './types';
+
+const stores = {
+  [StoreType.GLOBAL]: useGlobalStore,
+};
+
+/**
+ * Subscribes to a given `PublicSubject`
+ and updates the property or calls the callback when the subject's value changes.
+ *
+ * @template T - The type of the value emitted by the subject.
+ * @param {string} name - The name of the property to update with the subject's value.
+ * @param {PublicSubject<T>} subject - The subject to subscribe to.
+ * @param {(value: T) => void} [callback] - Optional callback function
+ to call with the subject's value.
+ *
+ * @returns {void}
+ */
+function subscribeTo<T>(
+  name: string,
+  subject: PublicSubject<T>,
+  callback?: (value: T) => void,
+): void {
+  subject.subscribe(this, () => {
+    if (callback) {
+      callback(subject.value);
+    } else {
+      this[name] = subject.value;
+    }
+
+    if (this.requestUpdate) this.requestUpdate();
+  });
+
+  if (!this.unsubscribeFrom) this.unsubscribeFrom = [];
+  this.unsubscribeFrom.push(subject.unsubscribe);
+}
+
+/**
+ * Hook to access and interact with a store.
+ *
+ * @template T - The type of the store.
+ * @param {T} name - The name of the store to access.
+ * @returns {Store<T>} A proxy object that allows interaction with the store.
+ *
+ * The returned proxy object provides the following functionalities:
+ * - `subscribe(callback?)`: Subscribes to changes in the store value.
+ * - `subject`: The current value of the store.
+ * - `value`: Getter for the current value of the store.
+ * - `publish(newValue)`: Updates the store with a new value.
+ *
+ * @example
+ * const myStore = useStore('myStoreName');
+ * myStore.subscribe((newValue) => {
+ *   console.log('Store value changed:', newValue);
+ * });
+ * myStore.publish('newValue');
+ */
+export function useStore<T extends StoreType>(name: T): Store<T> {
+  const storeData = stores[name as StoreType]();
+  const bindedSubscribeTo = subscribeTo.bind(this);
+
+  const proxy = new Proxy(storeData, {
+    get(store, valueName: string) {
+      if (valueName === 'destroy') return store.destroy;
+
+      return {
+        subscribe(callback?) {
+          bindedSubscribeTo(valueName, store[valueName], callback);
+        },
+        subject: store[valueName],
+        get value() {
+          return this.subject.value;
+        },
+        publish<T extends any>(newValue: T) {
+          this.subject.value = newValue;
+        },
+      };
+    },
+  });
+
+  return proxy as unknown as Store<T>;
+}

--- a/packages/room/src/stores/common/utils.ts
+++ b/packages/room/src/stores/common/utils.ts
@@ -1,0 +1,13 @@
+import { Singleton } from './types';
+
+export function CreateSingleton<T>(): Singleton<T> {
+  return {
+    set value(value: T) {
+      this.instance = value;
+      setTimeout(() => Object.freeze(this));
+    },
+    get value() {
+      return this.instance;
+    },
+  };
+}

--- a/packages/room/src/stores/global/index.ts
+++ b/packages/room/src/stores/global/index.ts
@@ -1,0 +1,47 @@
+import { Group } from '../../common/types/group.types';
+import { Participant } from '../../common/types/participant.types';
+import { Singleton } from '../common/types';
+import { CreateSingleton } from '../common/utils';
+import subject from '../subject';
+
+const instance: Singleton<GlobalStore> = CreateSingleton<GlobalStore>();
+
+export class GlobalStore {
+  public localParticipant = subject<Participant>({} as Participant);
+  public participants = subject<Record<string, Participant>>({});
+  public group = subject<Group>(null);
+  public hasJoinedRoom = subject<boolean>(false);
+
+  constructor() {
+    if (instance.value) {
+      throw new Error('GlobalStore is a singleton. There can only be one instance of it.');
+    }
+
+    instance.value = this;
+  }
+
+  public destroy() {
+    this.localParticipant.destroy();
+    this.participants.destroy();
+    this.group.destroy();
+    this.hasJoinedRoom.destroy();
+  }
+}
+
+const store = new GlobalStore();
+const destroy = store.destroy.bind(store);
+
+const group = store.group.expose();
+const participants = store.participants.expose();
+const localParticipant = store.localParticipant.expose();
+const hasJoinedRoom = store.hasJoinedRoom.expose();
+
+export function useGlobalStore() {
+  return {
+    localParticipant,
+    participants,
+    group,
+    hasJoinedRoom,
+    destroy,
+  };
+}

--- a/packages/room/src/stores/subject/index.test.ts
+++ b/packages/room/src/stores/subject/index.test.ts
@@ -1,0 +1,58 @@
+import subject, { Subject } from './index';
+
+describe('Subject', () => {
+  let testSubject: Subject<number>;
+
+  beforeEach(() => {
+    testSubject = subject(0);
+  });
+
+  it('should initialize with the given state', () => {
+    expect(testSubject.state).toBe(0);
+  });
+
+  it('should update state and notify subscribers', () => {
+    const callback = jest.fn();
+    testSubject.subscribe('test', callback);
+
+    testSubject.expose().value = 1;
+    expect(testSubject.state).toBe(1);
+    expect(callback).toHaveBeenCalledWith(1);
+  });
+
+  it('should allow multiple subscriptions and notify all subscribers', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    testSubject.subscribe('test1', callback1);
+    testSubject.subscribe('test2', callback2);
+
+    testSubject.expose().value = 2;
+    expect(callback1).toHaveBeenCalledWith(2);
+    expect(callback2).toHaveBeenCalledWith(2);
+  });
+
+  it('should unsubscribe correctly', () => {
+    const callback = jest.fn();
+    testSubject.subscribe('test', callback);
+
+    testSubject.unsubscribe('test');
+    testSubject.expose().value = 3;
+    expect(callback).not.toHaveBeenCalledWith(3);
+  });
+
+  it('should reset state on destroy', () => {
+    testSubject.expose().value = 4;
+    expect(testSubject.state).toBe(4);
+
+    testSubject.destroy();
+    expect(testSubject.state).toBe(0);
+  });
+
+  it('should expose public methods correctly', () => {
+    const publicSubject = testSubject.expose();
+    expect(publicSubject.value).toBe(0);
+
+    publicSubject.value = 5;
+    expect(publicSubject.value).toBe(5);
+  });
+});

--- a/packages/room/src/stores/subject/index.ts
+++ b/packages/room/src/stores/subject/index.ts
@@ -1,0 +1,87 @@
+import { BehaviorSubject, distinctUntilChanged, shareReplay } from 'rxjs';
+import type { Subscription } from 'rxjs';
+
+import { PublicSubject } from '../common/types';
+
+export class Subject<T> {
+  public state: T;
+  private firstState: T;
+
+  private subject: BehaviorSubject<T>;
+  private subscriptions: Map<string | this, Subscription[]> = new Map();
+
+  constructor(state: T, subject: BehaviorSubject<T>) {
+    this.state = state;
+    this.firstState = state;
+
+    this.subject = subject.pipe(
+      distinctUntilChanged(),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    ) as BehaviorSubject<T>;
+  }
+
+  private getValue(): T {
+    return this.state;
+  }
+
+  private setValue = (newValue: T): void => {
+    this.state = newValue;
+    this.subject.next(this.state);
+  };
+
+  public subscribe = (subscriptionId: string | this, callback: (value: T) => void) => {
+    const subscription = this.subject.subscribe(callback);
+
+    if (this.subscriptions.has(subscriptionId)) {
+      this.subscriptions.get(subscriptionId).push(subscription);
+      return;
+    }
+
+    this.subscriptions.set(subscriptionId, [subscription]);
+  };
+
+  public unsubscribe(subscriptionId: string) {
+    this.subscriptions.get(subscriptionId)?.forEach((subscription) => subscription.unsubscribe());
+    this.subscriptions.delete(subscriptionId);
+  }
+
+  public destroy() {
+    this.subscriptions.clear();
+    this.subject.complete();
+
+    this.restart();
+  }
+
+  private restart() {
+    this.state = this.firstState;
+
+    this.subject = new BehaviorSubject<T>(this.firstState).pipe(
+      distinctUntilChanged(),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    ) as BehaviorSubject<T>;
+  }
+
+  public expose(): PublicSubject<T> {
+    const subscribe = this.subscribe.bind(this);
+    const unsubscribe = this.unsubscribe.bind(this);
+    const getter = this.getValue.bind(this);
+    const setter = this.setValue.bind(this);
+
+    return {
+      get value() {
+        return getter();
+      },
+      set value(newValue: T) {
+        setter(newValue);
+      },
+      subscribe,
+      unsubscribe,
+    };
+  }
+}
+
+export default function subject<T>(initialState: T): Subject<T> {
+  const subject = new BehaviorSubject<T>(initialState);
+
+  return new Subject<T>(initialState, subject);
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `Room` class by integrating a new store management system using a global store pattern. The changes include replacing the `participants` Map with a `Record`, introducing a `useStore` hook for managing state, and updating the test cases accordingly.

Key changes include:

### Store Management Integration:
* [`packages/room/src/core/index.ts`](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L19-R22): Replaced the `participants` Map with a `Record` and integrated the `useStore` hook for managing participants and other room states. This includes publishing and subscribing to store updates. [[1]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L19-R22) [[2]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L59-R66) [[3]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L130-R143) [[4]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64R155-R158) [[5]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L254-R273) [[6]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64R290-L276) [[7]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L287-R313) [[8]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L304-R334) [[9]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64R348-R351)
* [`packages/room/src/stores/common/types.ts`](diffhunk://#diff-e6efcf90d4f84feea1fb8a44e69b6794c2ebd9db79c8f9a64757e0bd3637ce96R1-R48): Added type definitions for the store and subjects, including `SimpleSubject`, `PublicSubject`, and `StoreType` enums.
* [`packages/room/src/stores/common/use-store.ts`](diffhunk://#diff-11c93707015c8efa7d6b993295eed9d2c023043685e792364facf2a39448053fR1-R84): Implemented the `useStore` hook to provide a proxy for interacting with the global store.
* [`packages/room/src/stores/global/index.ts`](diffhunk://#diff-96c561c4fc71f7e20885a6d8119cb1a51d686bc38d6ee5212d4e85948b4a9c4fR1-R47): Created a `GlobalStore` class to manage the global state, including participants, local participant, group, and room join status.

### Utility and Helper Functions:
* [`packages/room/src/stores/common/utils.ts`](diffhunk://#diff-adc64123fe1eab0e041b491bbba4d6dfd43a47ff1b003da48c39b311d493bf42R1-R13): Added a utility function `CreateSingleton` to manage singleton instances.

### Testing Enhancements:
* [`packages/room/src/core/index.test.ts`](diffhunk://#diff-c381a0f03fca676639f37c026f6862c7b3aed5821b3abd777b3f574a9d172134L111-R118): Updated test cases to handle the new async behavior and changes in participants' state management. [[1]](diffhunk://#diff-c381a0f03fca676639f37c026f6862c7b3aed5821b3abd777b3f574a9d172134L111-R118) [[2]](diffhunk://#diff-c381a0f03fca676639f37c026f6862c7b3aed5821b3abd777b3f574a9d172134L247-R248)
* [`packages/room/src/stores/subject/index.test.ts`](diffhunk://#diff-33858b025860a65cdc7708dc8f9887fadf761873485f34bd9c86a90bce0a8470R1-R58): Added tests for the `Subject` class to ensure correct state management and subscription handling.

These changes enhance the state management of the `Room` class, making it more modular and easier to maintain.