### PR TITLE
fix(YJS|SDK): remove unnecessary validation from components initialization

### DIFF
--- a/packages/sdk/src/components/base/index.ts
+++ b/packages/sdk/src/components/base/index.ts
@@ -39,13 +39,7 @@ export abstract class BaseComponent extends Observable {
     }
 
     const { config: globalConfig, eventBus, ioc } = params;
-    const { isDomainWhitelisted, hasJoinedRoom } = this.useStore(StoreType.GLOBAL);
-
-    if (!isDomainWhitelisted.value) {
-      const message = `Component ${this.name} can't be used because this website's domain is not whitelisted. Please add your domain in https://dashboard.superviz.com/developer`;
-      this.logger.log(message);
-      return;
-    }
+    const { hasJoinedRoom } = this.useStore(StoreType.GLOBAL);
 
     config.setConfig(globalConfig);
 

--- a/packages/sdk/src/core/launcher/index.ts
+++ b/packages/sdk/src/core/launcher/index.ts
@@ -44,12 +44,10 @@ export class Launcher extends Observable implements DefaultLauncher {
     const {
       localParticipant: globalParticipant,
       group,
-      isDomainWhitelisted,
     } = this.useStore(StoreType.GLOBAL);
     const { localParticipant, participants } = this.useStore(StoreType.CORE);
 
     globalParticipant.publish({ ...participant });
-    isDomainWhitelisted.subscribe(this.onAuthentication);
     globalParticipant.subscribe(this.onLocalParticipantUpdateOnStore);
 
     localParticipant.subscribe(this.onLocalParticipantUpdateOnCore);

--- a/packages/sdk/src/services/stores/global/index.ts
+++ b/packages/sdk/src/services/stores/global/index.ts
@@ -9,7 +9,6 @@ export class GlobalStore {
   public localParticipant = subject<Participant>({} as Participant);
   public participants = subject<Record<string, Participant>>({});
   public group = subject<Group>(null);
-  public isDomainWhitelisted = subject<boolean>(true);
   public hasJoinedRoom = subject<boolean>(false);
 
   constructor() {
@@ -24,7 +23,6 @@ export class GlobalStore {
     this.localParticipant.destroy();
     this.participants.destroy();
     this.group.destroy();
-    this.isDomainWhitelisted.destroy();
     this.hasJoinedRoom.destroy();
   }
 }
@@ -35,7 +33,6 @@ const destroy = store.destroy.bind(store);
 const group = store.group.expose();
 const participants = store.participants.expose();
 const localParticipant = store.localParticipant.expose();
-const isDomainWhitelisted = store.isDomainWhitelisted.expose();
 const hasJoinedRoom = store.hasJoinedRoom.expose();
 
 export function useGlobalStore() {
@@ -43,7 +40,6 @@ export function useGlobalStore() {
     localParticipant,
     participants,
     group,
-    isDomainWhitelisted,
     hasJoinedRoom,
     destroy,
   };

--- a/packages/yjs/src/provider/index.test.ts
+++ b/packages/yjs/src/provider/index.test.ts
@@ -73,7 +73,6 @@ describe('provider', () => {
 
       provider.attach({
         useStore: () => ({
-          isDomainWhitelisted: { value: true },
           hasJoinedRoom: { value: true },
           localParticipant: { value: { id: 'local-participant-id' } },
         }),
@@ -83,27 +82,12 @@ describe('provider', () => {
       expect(provider['connect']).toHaveBeenCalled();
     });
 
-    test('should not connect if domain is not whitelisted', () => {
-      const provider = createProvider();
-      provider['connect'] = jest.fn();
-
-      provider.attach({
-        useStore: () => ({
-          isDomainWhitelisted: { value: false },
-          hasJoinedRoom: { value: true },
-        }),
-      } as any);
-
-      expect(provider['connect']).not.toHaveBeenCalled();
-    });
-
     test('should not connect if user has not joined room', () => {
       const provider = createProvider();
       provider['connect'] = jest.fn();
 
       provider.attach({
         useStore: () => ({
-          isDomainWhitelisted: { value: true },
           hasJoinedRoom: { value: false, subscribe: jest.fn() },
         }),
       } as any);

--- a/packages/yjs/src/provider/index.ts
+++ b/packages/yjs/src/provider/index.ts
@@ -63,13 +63,7 @@ export class SuperVizYjsProvider extends ObservableV2<Events> {
     }
 
     const { useStore, ioc, config } = params;
-    const { isDomainWhitelisted, hasJoinedRoom, localParticipant } = useStore(storeType.GLOBAL);
-
-    if (!isDomainWhitelisted.value) {
-      const message = `Component ${this.name} can't be used because this website's domain is not whitelisted. Please add your domain in https://dashboard.superviz.com/developer`;
-      this.logger.log(message);
-      return;
-    }
+    const { hasJoinedRoom, localParticipant } = useStore(storeType.GLOBAL);
 
     if (!hasJoinedRoom.value) {
       hasJoinedRoom.subscribe(() => this.attach(params));


### PR DESCRIPTION
This pull request removes the domain whitelisting feature from the SDK. The most important changes include the removal of the `isDomainWhitelisted` property and associated logic from various components and tests.

### Removal of domain whitelisting feature:

* [`packages/sdk/src/components/base/index.ts`](diffhunk://#diff-46a77478ef6fa20fbf85f0adae9742a37602a57bd3679e5dbf79186f9f56ca00L42-R42): Removed the check for `isDomainWhitelisted` and the associated log message.
* [`packages/sdk/src/core/launcher/index.ts`](diffhunk://#diff-a656ec0a225c00682130501cbf050043c015a7c41d8e0587f31908e61dc9ecf4L47-L52): Removed the `isDomainWhitelisted` property and its subscription in the `Launcher` class.
* [`packages/sdk/src/services/stores/global/index.ts`](diffhunk://#diff-bbfe56c41e082158e00195955ee849f4216ae47bbc5ef65accfc19f59369c8d2L12): Removed the `isDomainWhitelisted` property and its destruction in the `GlobalStore` class. [[1]](diffhunk://#diff-bbfe56c41e082158e00195955ee849f4216ae47bbc5ef65accfc19f59369c8d2L12) [[2]](diffhunk://#diff-bbfe56c41e082158e00195955ee849f4216ae47bbc5ef65accfc19f59369c8d2L27) [[3]](diffhunk://#diff-bbfe56c41e082158e00195955ee849f4216ae47bbc5ef65accfc19f59369c8d2L38-L46)
* [`packages/yjs/src/provider/index.test.ts`](diffhunk://#diff-0fd4675fcece2d9329edeb5f087fe45c0eb5f88509a292bb61c453dbc8bce3abL76): Removed tests related to the `isDomainWhitelisted` property. [[1]](diffhunk://#diff-0fd4675fcece2d9329edeb5f087fe45c0eb5f88509a292bb61c453dbc8bce3abL76) [[2]](diffhunk://#diff-0fd4675fcece2d9329edeb5f087fe45c0eb5f88509a292bb61c453dbc8bce3abL86-L106)
* [`packages/yjs/src/provider/index.ts`](diffhunk://#diff-5facc7e2f17e4c62604219a553d86292b82c93dab59290357ee6802c2d4e9ba7L66-R66): Removed the check for `isDomainWhitelisted` and the associated log message in the `SuperVizYjsProvider` class.