### PR TITLE
feat: create a particular type to the room state

### DIFF
--- a/packages/room/src/core/index.test.ts
+++ b/packages/room/src/core/index.test.ts
@@ -5,7 +5,7 @@ import { Logger } from '../common/utils/logger';
 import { IOC } from '../services/io';
 import { IOCState } from '../services/io/types';
 
-import { ParticipantEvent, RoomParams } from './types';
+import { ParticipantEvent, RoomParams, RoomState } from './types';
 
 import { Room } from './index';
 
@@ -212,7 +212,7 @@ describe('Room', () => {
   });
 
   it('should get participants when room is connected', async () => {
-    room['state'] = IOCState.CONNECTED;
+    room['state'] = RoomState.CONNECTED;
 
     const date = Date.now();
 
@@ -249,7 +249,7 @@ describe('Room', () => {
   });
 
   it('should return empty array when room is not connected', async () => {
-    room['state'] = IOCState.DISCONNECTED;
+    room['state'] = RoomState.DISCONNECTED;
 
     const participants = await room.getParticipants();
 

--- a/packages/room/src/core/types.ts
+++ b/packages/room/src/core/types.ts
@@ -11,7 +11,16 @@ type RoomError = {
 }
 
 type RoomUpdate = {
-  status: IOCState,
+  status: RoomState | `${RoomState}`
+}
+
+export enum RoomState {
+  CONNECTED = 'CONNECTED',
+  CONNECTING = 'CONNECTING',
+  DISCONNECTED = 'DISCONNECTED',
+  CONNECTION_ERROR = 'CONNECTION_ERROR',
+  RECONNECTING = 'RECONNECTING',
+  RECONNECT_ERROR = 'RECONNECT_ERROR',
 }
 
 export enum ParticipantEvent {

--- a/packages/room/src/index.ts
+++ b/packages/room/src/index.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { InitialParticipant, Participant } from './common/types/participant.types';
 import { Room } from './core';
-import { Callback, ParticipantEvent, RoomEvent } from './core/types';
+import { Callback, ParticipantEvent, RoomEvent, RoomState } from './core/types';
 import { ApiService } from './services/api';
 import config from './services/config';
 import { InitializeRoomParams, InitializeRoomSchema } from './types';
@@ -147,6 +147,7 @@ export {
   RoomEvent,
   ParticipantEvent,
   Callback,
+  RoomState,
 };
 
 if (typeof window !== 'undefined') {
@@ -154,5 +155,6 @@ if (typeof window !== 'undefined') {
     createRoom,
     RoomEvent,
     ParticipantEvent,
+    RoomState,
   };
 }

--- a/packages/room/src/shims.d.ts
+++ b/packages/room/src/shims.d.ts
@@ -2,7 +2,7 @@ import { Room } from './core';
 
 declare global {
   interface Window {
-    SuperVizRoom: {};
+    SuperVizRoom: Record<string, unknown>;
     SUPERVIZ_ROOM: Room;
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `Room` module to replace the `IOCState` references with the new `RoomState` enum. The changes ensure consistency and improve code readability by using a more descriptive enum for room state management.

### Changes related to Room State Management:

* [`packages/room/src/core/types.ts`](diffhunk://#diff-19019efac8d6931240e1dab44310725e9c94c26cb952afa5cdbc004d71fb8711L14-R23): Added the `RoomState` enum to define possible room states such as `CONNECTED`, `CONNECTING`, `DISCONNECTED`, `CONNECTION_ERROR`, `RECONNECTING`, and `RECONNECT_ERROR`. Updated `RoomUpdate` type to use `RoomState` instead of `IOCState`.
* [`packages/room/src/core/index.ts`](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L23-R23): Replaced all occurrences of `IOCState` with `RoomState` for room state management in the `Room` class. This includes updating the initial state, state transitions in the `leave` method, and state checks in the `getParticipants` method. [[1]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L23-R23) [[2]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L42-R42) [[3]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L126-R126) [[4]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64L399-R410)
* [`packages/room/src/core/index.test.ts`](diffhunk://#diff-c381a0f03fca676639f37c026f6862c7b3aed5821b3abd777b3f574a9d172134L215-R215): Updated test cases to use `RoomState` instead of `IOCState` for setting up and validating room states. [[1]](diffhunk://#diff-c381a0f03fca676639f37c026f6862c7b3aed5821b3abd777b3f574a9d172134L215-R215) [[2]](diffhunk://#diff-c381a0f03fca676639f37c026f6862c7b3aed5821b3abd777b3f574a9d172134L252-R252)
* [`packages/room/src/index.ts`](diffhunk://#diff-78719ce3638e8ed5c2d90d38ca3bf38abfde61062d30667064dcaf92906d70f3L6-R6): Included `RoomState` in the imports and exports to ensure it is available for use throughout the module. [[1]](diffhunk://#diff-78719ce3638e8ed5c2d90d38ca3bf38abfde61062d30667064dcaf92906d70f3L6-R6) [[2]](diffhunk://#diff-78719ce3638e8ed5c2d90d38ca3bf38abfde61062d30667064dcaf92906d70f3R150-R158)

These changes enhance the maintainability and clarity of the code by using a dedicated enum for room states.