### PR TITLE
feat: introducing event bus to room

### DIFF
--- a/packages/room/src/core/index.ts
+++ b/packages/room/src/core/index.ts
@@ -3,6 +3,7 @@ import { Subject, Subscription, timestamp } from 'rxjs';
 
 import { InitialParticipant, Participant } from '../common/types/participant.types';
 import { Logger } from '../common/utils/logger';
+import { EventBus } from '../services/event-bus';
 import { IOC } from '../services/io';
 import { IOCState } from '../services/io/types';
 import { SlotService } from '../services/slot';
@@ -26,10 +27,13 @@ export class Room {
   private subscriptions: Map<Callback<GeneralEvent>, Subscription> = new Map();
   private observers: Map<string, Subject<unknown>> = new Map();
 
+  private eventBus: EventBus;
+
   constructor(params: RoomParams) {
     this.io = new IOC(params.participant);
     this.participant = this.createParticipant(params.participant);
     this.logger = new Logger('@superviz/room/room');
+    this.eventBus = new EventBus();
 
     this.logger.log('room created', this.participant);
     this.init();
@@ -64,6 +68,8 @@ export class Room {
 
     hasJoinedRoom.publish(false);
     destroyStore();
+
+    this.eventBus?.destroy();
 
     if (typeof window !== 'undefined') {
       delete window.SUPERVIZ_ROOM;

--- a/packages/room/src/services/event-bus/index.test.ts
+++ b/packages/room/src/services/event-bus/index.test.ts
@@ -1,0 +1,92 @@
+import { Subject } from 'rxjs';
+
+import { EventBus } from './index';
+
+jest.mock('rxjs', () => ({
+  Subject: jest.fn().mockImplementation(() => ({
+    next: jest.fn(),
+    subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+    complete: jest.fn(),
+  })),
+}));
+
+jest.mock('../../common/utils/logger', () => ({
+  Logger: jest.fn().mockImplementation(() => ({
+    log: jest.fn(),
+  })),
+}));
+
+describe('EventBus', () => {
+  let eventBus: EventBus;
+
+  beforeEach(() => {
+    eventBus = new EventBus();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create an instance of EventBus', () => {
+    expect(eventBus).toBeInstanceOf(EventBus);
+  });
+
+  it('should log creation of event bus', () => {
+    expect(eventBus['logger'].log).toHaveBeenCalledWith('event-bus created');
+  });
+
+  it('should subscribe to an event', () => {
+    const callback = jest.fn();
+    eventBus.subscribe('testEvent', callback);
+
+    expect(eventBus['logger'].log).toHaveBeenCalledWith('event-bus @ subscribe', 'testEvent');
+    expect(eventBus['observers'].get('testEvent')).not.toBeUndefined();
+    expect(eventBus['subscriptions'].get(callback)).toBeDefined();
+  });
+
+  it('should unsubscribe from an event', () => {
+    const callback = jest.fn();
+    eventBus.subscribe('testEvent', callback);
+    eventBus.unsubscribe('testEvent', callback);
+
+    expect(eventBus['logger'].log).toHaveBeenCalledWith('event-bus @ unsubscribe', 'testEvent');
+    expect(eventBus['subscriptions'].get(callback)).toBeUndefined();
+  });
+
+  it('should unsubscribe all callbacks from an event', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    eventBus.subscribe('testEvent', callback1);
+    eventBus.subscribe('testEvent', callback2);
+    eventBus.unsubscribe('testEvent');
+
+    expect(eventBus['logger'].log).toHaveBeenCalledWith('event-bus @ unsubscribe', 'testEvent');
+    expect(eventBus['observers'].get('testEvent')).toBeUndefined();
+  });
+
+  it('should publish an event', () => {
+    const callback = jest.fn();
+    eventBus.subscribe('testEvent', callback);
+    eventBus.publish('testEvent', 'testData');
+
+    expect(eventBus['logger'].log).toHaveBeenCalledWith('event-bus @ publish', 'testEvent');
+    expect(eventBus['observers'].get('testEvent')?.next).toHaveBeenCalledWith('testData');
+  });
+
+  it('should not publish an event if no observers', () => {
+    eventBus.publish('testEvent', 'testData');
+
+    expect(eventBus['logger'].log).toHaveBeenCalledWith('event-bus @ publish', 'testEvent');
+    expect(eventBus['observers'].get('testEvent')).toBeUndefined();
+  });
+
+  it('should destroy the event bus', () => {
+    const callback = jest.fn();
+    eventBus.subscribe('testEvent', callback);
+    eventBus.destroy();
+
+    expect(eventBus['logger'].log).toHaveBeenCalledWith('event-bus @ destroy');
+    expect(eventBus['subscriptions'].size).toBe(0);
+    expect(eventBus['observers'].size).toBe(0);
+  });
+});

--- a/packages/room/src/services/event-bus/index.ts
+++ b/packages/room/src/services/event-bus/index.ts
@@ -1,0 +1,90 @@
+import { Subject, Subscription } from 'rxjs';
+
+import { Logger } from '../../common/utils/logger';
+
+type Callback<T> = (event: T) => void;
+
+export class EventBus {
+  private logger: Logger;
+
+  private subscriptions: Map<Callback<unknown>, Subscription> = new Map();
+  private observers: Map<string, Subject<unknown>> = new Map();
+
+  constructor() {
+    this.logger = new Logger('@superviz/room/event-bus');
+    this.logger.log('event-bus created');
+  }
+
+  /**
+     * @description Listen to an event
+     * @param event - The event to listen to
+     * @param callback - The callback to execute when the event is emitted
+     * @returns {void}
+     */
+  public subscribe<E>(
+    event: string,
+    callback: Callback<E>,
+  ): void {
+    this.logger.log('event-bus @ subscribe', event);
+
+    let subject = this.observers.get(event);
+
+    if (!subject) {
+      subject = new Subject<E>();
+      this.observers.set(event, subject);
+    }
+
+    this.subscriptions.set(callback, subject.subscribe(callback));
+  }
+
+  /**
+     * @description Stop listening to an event
+     * @param event - The event to stop listening to
+     * @param callback - The callback to remove from the event
+     * @returns {void}
+     */
+  public unsubscribe<E>(
+    event: string,
+    callback?: Callback<E>,
+  ): void {
+    this.logger.log('event-bus @ unsubscribe', event);
+
+    if (!callback) {
+      this.observers.delete(event as string);
+      return;
+    }
+
+    this.subscriptions.get(callback)?.unsubscribe();
+    this.subscriptions.delete(callback);
+  }
+
+  /**
+     * Emits an event to the observers.
+     *
+     * @template E - The type of the event.
+     * @param event - The event options containing the event type.
+     * @param data - The payload data associated with the event.
+     * @returns void
+     */
+  public publish<E>(
+    event: string,
+    data: E,
+  ): void {
+    this.logger.log('event-bus @ publish', event);
+    const subject = this.observers.get(event);
+
+    if (!subject) return;
+
+    subject.next(data);
+  }
+
+  public destroy(): void {
+    this.logger.log('event-bus @ destroy');
+
+    this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+    this.subscriptions.clear();
+
+    this.observers.forEach((observer) => observer.complete());
+    this.observers.clear();
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `EventBus` service to the `Room` module, which facilitates event-driven communication within the application. The changes include the addition of the `EventBus` class, its integration into the `Room` class, and the creation of unit tests for the `EventBus`.

### EventBus Service Implementation:
* [`packages/room/src/services/event-bus/index.ts`](diffhunk://#diff-b0a429606bb61e6c7a852fed00f74c4877a6434dd78130fcc583af8ada151aa4R1-R90): Added a new `EventBus` class that provides methods to subscribe, unsubscribe, publish events, and destroy the event bus.

### Integration into Room Class:
* [`packages/room/src/core/index.ts`](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64R6): Integrated the `EventBus` into the `Room` class by importing the `EventBus`, initializing it in the constructor, and ensuring it is destroyed when the room is destroyed. [[1]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64R6) [[2]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64R30-R36) [[3]](diffhunk://#diff-de9fc9424da62da8d6bae1eca70699fec3311623098740534ac6e9fca381bb64R72-R73)

### Unit Tests for EventBus:
* [`packages/room/src/services/event-bus/index.test.ts`](diffhunk://#diff-05b6a573564e57b54127cc9ff13eeff9bfdcd17a8442096af26e361b6143d20bR1-R92): Added unit tests for the `EventBus` class to ensure its methods (subscribe, unsubscribe, publish, and destroy) work as expected and log the appropriate messages.